### PR TITLE
IC_Camera.py: Remove unneeded future dependency

### DIFF
--- a/pyicic/IC_Camera.py
+++ b/pyicic/IC_Camera.py
@@ -4,7 +4,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from builtins import object
-from past.utils import old_div
 from ctypes import *
 import time
 
@@ -452,7 +451,7 @@ class IC_Camera(object):
         
         img_width = image_size[0]
         img_height = image_size[1]
-        img_depth = old_div(image_size[2], 8)
+        img_depth = image_size[2] // 8
         buffer_size = img_width * img_height * img_depth * sizeof(c_uint8)
 
         img_ptr = self.get_image_ptr()


### PR DESCRIPTION
Replaces division on line 454 by explicit floor division, which works because  `from __future__ import division`.

This removes the unnecessary dependency of this module on `past.utils` (i.e. the `future` module).